### PR TITLE
Ra/digger module

### DIFF
--- a/lib/digger.rb
+++ b/lib/digger.rb
@@ -5,7 +5,9 @@ module Digger
   end
 
   def game(game_id)
-
+    all_games = []
+    @seasons.each {|season| all_games << season.games_by_type.values}
+    all_games.flatten.find {|game| game.id == game_id}
   end
 
 end

--- a/lib/digger.rb
+++ b/lib/digger.rb
@@ -1,0 +1,9 @@
+module Digger
+
+  def team(team_id)
+    @teams.find {|team| team.id == team_id}
+  end
+
+  def game(game_id)
+
+end

--- a/lib/season.rb
+++ b/lib/season.rb
@@ -22,4 +22,8 @@ class Season
   def number_of_games_by_type(type)
     games_by_type[type].length
   end
+
+  def total_games
+    @games_by_type.values.flatten.length
+  end
 end

--- a/lib/season.rb
+++ b/lib/season.rb
@@ -18,4 +18,8 @@ class Season
     end
     game_sort_hash
   end
+
+  def number_of_games_by_type(type)
+    games_by_type[type].length
+  end
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -1,8 +1,10 @@
 require "CSV"
 require_relative './team'
 require_relative './season'
+require_relative './digger'
 
 class StatTracker
+	include Digger
 	attr_reader :seasons, :teams, :game_teams, :locations
 
 	def initialize(locations)

--- a/test/season_test.rb
+++ b/test/season_test.rb
@@ -22,4 +22,13 @@ class SeasonTest < MiniTest::Test
     # assert_equal false, @season.games_by_type["Postseason"].include?(2012020510)
     # assert_equal true, @season.games_by_type["Regular Season"].include?(2012020510)
   end
+
+  def test_can_total_games_by_type
+    assert_equal 86, @season.number_of_games_by_type("Postseason")
+    assert_equal 720, @season.number_of_games_by_type("Regular Season")
+  end
+
+  def test_find_total_games_in_season
+    assert_equal 806, @season.total_games
+  end
 end

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -31,8 +31,13 @@ class StatTrackerTest < Minitest::Test
 	end
 
 	def test_dig_module_can_pull_single_team
-		
+		assert_instance_of Team, @stat_tracker.team(17)
+		assert_equal 17, @stat_tracker.team(17).id
 	end
 
+	def test_dig_module_can_pull_single_game
+		assert_instance_of Game, @stat_tracker.game(2012030221)
+		assert_equal 2012030221, @stat_tracker.game(2012030221).id
 	end
+
 end

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -29,4 +29,10 @@ class StatTrackerTest < Minitest::Test
 		assert_instance_of Team, @stat_tracker.teams.first
 		assert_instance_of Team, @stat_tracker.teams.last
 	end
+
+	def test_dig_module_can_pull_single_team
+		
+	end
+
+	end
 end


### PR DESCRIPTION
Digger Module is setup for the Stat_Tracker to use.  Each on is based an ID for a team or a game and returns that specific object of the team or game.

Season Methods were given to find total number of games in a season as well as total number of games in a season based on that type.